### PR TITLE
Fix: replace strlen with length parameter

### DIFF
--- a/lib/webhdfspp/io_service.cc
+++ b/lib/webhdfspp/io_service.cc
@@ -176,7 +176,7 @@ Status IoServiceImpl::DoPutCreate(const URIBuilder &uri, const char* data, size_
 
   struct DataUpload data_upload;
   data_upload.read_pointer = data;
-  data_upload.size_left = strlen(data);
+  data_upload.size_left = length;
 
   CURL* redirect_handle = curl_easy_init();
   char error_buffer_redirect[CURL_ERROR_SIZE];


### PR DESCRIPTION
Relying on strlen caused issues when uploading Parquet formatted data.